### PR TITLE
Adding support for scanning private repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ deletes (or disables/warns depending on configuration) the exposed tokens.
 ### Feature Overview
 - Define git repos to scan using a CRD
 - Scan repos at custom-defined intervals
+- Scan private repos using http basic auth or ssh auth
 - Automatically delete/disable/warn (based on configuration) exposed rancher tokens
 - Works with token hashing enabled or disabled
 
@@ -41,3 +42,7 @@ Common commands include:
 - `make`, for when you want to re-build the application. The application can then be run with `./bin/manager`
 - `make install`, for when you need to install the relevant crds into the cluster before running the application.
 - `make manifests`, for when you make a change to the crds and need to re-generate their definitions
+
+## Docs
+
+See the `docs` directory for detailed docs on various features (such as setting up private repo authentication).

--- a/api/v3/gitreposcan_types.go
+++ b/api/v3/gitreposcan_types.go
@@ -38,13 +38,16 @@ type GitRepoScanSpec struct {
 	RepoUrl string `json:"repoUrl"`
 
 	// RepoSecretName is the name of the secret (in the same namespace as the chart is installed in) containing the secret
-	// to access the repo at RepoUrl. If empty, uses the secret configured when installing the controller
-	// TODO: Update this with information on variable which controls the controller default
+	// to access the repo at RepoUrl. If empty, uses the secret configured when installing the controller (
 	RepoSecretName string `json:"repoSecretName,omitempty"`
 
 	// ScanIntervalSeconds is time between the last scan's start time and the next time a scan will be run. If empty/0,
 	// uses the default fed into the controller/chart with the -default-scan-interval arg
 	ScanIntervalSeconds int `json:"scanIntervalSeconds,omitempty"`
+
+	// ForceNoAuth, if true, forces scans for this repo to ignore other settings to use a secret to clone/pull from the repo
+	// Useful for forcing a scan to ignore auth settings setup at the controller level
+	ForceNoAuth bool `json:"forceNoAuth,omitempty"`
 }
 
 // GitRepoScanStatus defines the observed state of GitRepoScan

--- a/config/crd/bases/management.cattle.io_gitreposcans.yaml
+++ b/config/crd/bases/management.cattle.io_gitreposcans.yaml
@@ -35,12 +35,17 @@ spec:
           spec:
             description: GitRepoScanSpec defines the desired state of GitRepoScan
             properties:
+              forceNoAuth:
+                description: ForceNoAuth, if true, forces scans for this repo to ignore
+                  other settings to use a secret to clone/pull from the repo Useful
+                  for forcing a scan to ignore auth settings setup at the controller
+                  level
+                type: boolean
               repoSecretName:
-                description: 'RepoSecretName is the name of the secret (in the same
+                description: RepoSecretName is the name of the secret (in the same
                   namespace as the chart is installed in) containing the secret to
                   access the repo at RepoUrl. If empty, uses the secret configured
-                  when installing the controller TODO: Update this with information
-                  on variable which controls the controller default'
+                  when installing the controller (
                 type: string
               repoUrl:
                 description: RepoUrl defines the target git repo to scan. Can be in

--- a/config/samples/management_v3_gitreposcan.yaml
+++ b/config/samples/management_v3_gitreposcan.yaml
@@ -12,3 +12,19 @@ metadata:
 spec:
   repoUrl: https://github.com/MbolotSuse/token-revoker-test.git
   scanIntervalSeconds: 60
+---
+apiVersion: management.cattle.io/v3
+kind: GitRepoScan
+metadata:
+  labels:
+    app.kubernetes.io/name: gitreposcan
+    app.kubernetes.io/instance: gitreposcan-sample
+    app.kubernetes.io/part-of: rancher-token-revoker
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/created-by: rancher-token-revoker
+  name: privatescan-sample
+  namespace: test-ns
+spec:
+  repoUrl: git@github.com:MbolotSuse/token-revoker-private-test.git
+  scanIntervalSeconds: 60
+  repoSecretName: deploy-key

--- a/controllers/gitreposcan_controller.go
+++ b/controllers/gitreposcan_controller.go
@@ -22,17 +22,23 @@ import (
 	"sync"
 	"time"
 
+	"github.com/go-git/go-git/v5/plumbing/transport"
+	"github.com/go-git/go-git/v5/plumbing/transport/http"
+	"github.com/go-git/go-git/v5/plumbing/transport/ssh"
+	managementv3 "github.com/mbolotsuse/rancher-token-revoker/api/v3"
+	"github.com/mbolotsuse/rancher-token-revoker/revoker"
 	"github.com/mbolotsuse/rancher-token-revoker/scanner"
 	rancherv3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/sirupsen/logrus"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/log"
-
-	managementv3 "github.com/mbolotsuse/rancher-token-revoker/api/v3"
-	"github.com/mbolotsuse/rancher-token-revoker/revoker"
 )
+
+// gitSSHUser defines the user to attempt to auth as when cloning a private repo. For github/gitlab this appears to be
+// git. Might be good to make this customizable in the future
+const gitSSHUser = "git"
 
 // GitRepoScanReconciler reconciles a GitRepoScan object
 type GitRepoScanReconciler struct {
@@ -40,8 +46,12 @@ type GitRepoScanReconciler struct {
 	Scheme *runtime.Scheme
 	// DefaultScanInterval is the scan interval which should be used if no scan interval is specified for a given CR
 	DefaultScanInterval int
+	// DefaultAuthSecret is the secret used to pull from private repos if no cred is specified for that repo
+	DefaultAuthSecret string
 	// RevokerMode is the mode of the tokenRevoker
-	RevokerMode  revoker.Mode
+	RevokerMode revoker.Mode
+	// Namespace is the namespace that the controller is running in
+	Namespace    string
 	scanHandlers sync.Map
 }
 
@@ -49,17 +59,9 @@ type GitRepoScanReconciler struct {
 //+kubebuilder:rbac:groups=management.cattle.io,resources=gitreposcans/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=management.cattle.io,resources=gitreposcans/finalizers,verbs=update
 
-// Reconcile is part of the main kubernetes reconciliation loop which aims to
-// move the current state of the cluster closer to the desired state.
-// TODO(user): Modify the Reconcile function to compare the state specified by
-// the GitRepoScan object against the actual cluster state, and then
-// perform operations to make the cluster state reflect the state specified by
-// the user.
-//
-// For more details, check Reconcile and its Result here:
-// - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.14.1/pkg/reconcile
+// Reconcile attempts to launch a go-routine processing a scan of a repo. If an existing repo scan is already running
+// it cancels the current scan before launching a new one (to ensure that the new settings take effect)
 func (r *GitRepoScanReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	_ = log.FromContext(ctx)
 	// if we have a running handler, stop it so that we can restart it with the update configuration
 	if value, ok := r.scanHandlers.Load(req.NamespacedName); ok {
 		logrus.Infof("Stopping watch for %s", req.NamespacedName)
@@ -78,9 +80,40 @@ func (r *GitRepoScanReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	cancelContext, cancelFunc := context.WithCancel(ctx)
 	r.scanHandlers.Store(req.NamespacedName, cancelFunc)
 
-	repoScanner := scanner.GitRepoScanner{
-		RepoUrl: scan.Spec.RepoUrl,
+	var gitAuthSecret string
+	isDefault := false
+	// use the value specified for this repo, or fallback to the default provided for the controller
+	if scan.Spec.RepoSecretName != "" {
+		gitAuthSecret = scan.Spec.RepoSecretName
+		isDefault = true
+	} else if r.DefaultAuthSecret != "" {
+		gitAuthSecret = r.DefaultAuthSecret
 	}
+
+	var repoScanner scanner.GitRepoScanner
+	if gitAuthSecret != "" {
+		authMethod, err := r.readAuthMethodFromSecret(gitAuthSecret)
+		if err != nil {
+			errorMessage := fmt.Sprintf("unable to create auth method from secret: %s", err)
+			if isDefault {
+				errorMessage = fmt.Sprintf("unable to create auth method from default application secret")
+				logrus.Errorf("unable to create auth method from default secret: %s", err.Error())
+			}
+			// The user may/may not be able to see the controller logs, but they will be able to see the status on their
+			// repo scan, so update the scan object accordingly
+			_, err := r.updateScanStatus(scan, false, errorMessage)
+			return ctrl.Result{Requeue: false}, fmt.Errorf("unable to read auth method from secret: %w", err)
+		}
+		repoScanner = scanner.GitRepoScanner{
+			RepoUrl:    scan.Spec.RepoUrl,
+			AuthMethod: authMethod,
+		}
+	} else {
+		repoScanner = scanner.GitRepoScanner{
+			RepoUrl: scan.Spec.RepoUrl,
+		}
+	}
+
 	err = repoScanner.Start()
 	if err != nil {
 		logrus.Infof("%t", err == nil)
@@ -99,7 +132,7 @@ func (r *GitRepoScanReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	return ctrl.Result{}, nil
 }
 
-// scanConfig holds all of the args required to scan a single repo
+// scanConfig holds the args required to scan a single repo
 type scanConfig struct {
 	scan    managementv3.GitRepoScan
 	scanner scanner.GitRepoScanner
@@ -114,8 +147,6 @@ func (r *GitRepoScanReconciler) startRepoScans(ctx context.Context, config scanC
 	tickInterval := time.Duration(duration) * time.Second
 	ticker := time.NewTicker(tickInterval)
 	logrus.Infof("running scan of repo %s every %d seconds", config.scan.Name+"/"+config.scan.Namespace, duration)
-	// TODO: update cr on scan with
-	// time.Now().Format(time.RFC3339)
 	for {
 		select {
 		case <-ctx.Done():
@@ -130,7 +161,19 @@ func (r *GitRepoScanReconciler) startRepoScans(ctx context.Context, config scanC
 			reports, err := config.scanner.Scan()
 			if err != nil {
 				logrus.Errorf("unable to scan repo %s", err.Error())
+				newScan, updErr := r.updateScanStatus(config.scan, false, err.Error())
+				if updErr != nil {
+					logrus.Errorf("unable to update scan status %s", updErr.Error())
+					continue
+				}
+				config.scan = *newScan
 				continue
+			}
+			newScan, updErr := r.updateScanStatus(config.scan, true, "")
+			if updErr != nil {
+				logrus.Errorf("unable to update scan status %s", updErr.Error())
+			} else {
+				config.scan = *newScan
 			}
 			logrus.Infof("found %d exposed credentials", len(reports))
 			for _, report := range reports {
@@ -142,6 +185,56 @@ func (r *GitRepoScanReconciler) startRepoScans(ctx context.Context, config scanC
 			}
 		}
 	}
+}
+
+// readAuthMethodFromSecret fetches the specified secret in the controller's namespace and converts to the applicable AuthMethod
+func (r *GitRepoScanReconciler) readAuthMethodFromSecret(secretName string) (transport.AuthMethod, error) {
+	secretKey := client.ObjectKey{
+		Name:      secretName,
+		Namespace: r.Namespace,
+	}
+	var secret v1.Secret
+	err := r.Client.Get(context.Background(), secretKey, &secret)
+	if err != nil {
+		return nil, fmt.Errorf("unable to get scret: %w", err)
+	}
+	switch secret.Type {
+	case v1.SecretTypeBasicAuth:
+		username, ok := secret.StringData[v1.BasicAuthUsernameKey]
+		// k8s should be validating these fields, but double-check it just in case
+		if !ok {
+			return nil, fmt.Errorf("secret was of type %s, but there was no %s key", v1.SecretTypeBasicAuth, v1.BasicAuthUsernameKey)
+		}
+		password, ok := secret.StringData[v1.BasicAuthPasswordKey]
+		if !ok {
+			return nil, fmt.Errorf("secret was of type %s, bu there was no %s key", v1.SecretTypeBasicAuth, v1.BasicAuthPasswordKey)
+		}
+		return &http.BasicAuth{Username: username, Password: password}, nil
+	case v1.SecretTypeSSHAuth:
+		privateKey, ok := secret.Data[v1.SSHAuthPrivateKey]
+		if !ok {
+			return nil, fmt.Errorf("secret was of type %s, bu there was no %s key", v1.SecretTypeSSHAuth, v1.SSHAuthPrivateKey)
+		}
+		// password should be empty. This value is not expected to be encrypted with a passphrase, since any passphrase
+		// would have to be fed to the application through a secret.
+		return ssh.NewPublicKeys(gitSSHUser, privateKey, "")
+	default:
+		return nil, fmt.Errorf("unrecognized secret type %s, ensure that the secret type is one of the approved types", secret.Type)
+	}
+}
+
+// updateScanStatus updates the status of a scan. Success should be false if we failed. Message should only be non-empty
+// if we failed
+func (r *GitRepoScanReconciler) updateScanStatus(scan managementv3.GitRepoScan, success bool, message string) (*managementv3.GitRepoScan, error) {
+	scanTime := time.Now().Format(time.RFC3339)
+	scan.Status.LastScanTime = scanTime
+	if !success {
+		scan.Status.ScanError = &managementv3.RepoScanError{
+			ErrorMessage: message,
+		}
+	}
+	err := r.Update(context.Background(), &scan)
+	return &scan, err
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/docs/private_repos.md
+++ b/docs/private_repos.md
@@ -1,0 +1,109 @@
+## Overview
+
+There are two supported methods of private auth, http basic (username/password) and ssh keys. Both methods require you to create a secret (with the appropriate type) in the namespace that the revoker is installed in (usually cattle-revoker-system). The revoker only has permission to get secrets in the namespace it is installed in as a security best practice, so while you can create ScanConfigurations in any namespace, you will need to create these secrets in the namespace that the revoker is installed in.
+
+You can then specify the secret as either part of the individual scan configuration or the configuration for the controller. As a best practice, it's a good idea to create only one secret (generally an ssh key), which you specify as part of the controller/chart. This secret should be configured to have access to each repo that you want to scan (either by associating the secret with a bot account that has access to each repo, or by adding the secret to the repo directly).
+
+Refer to the following github docs for examples on the use of ssh keys for auth:
+- [Deploy Keys](https://docs.github.com/en/developers/overview/managing-deploy-keys#deploy-keys)
+- [Adding SSH Keys to a user account](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account)
+
+You can force the revoker to use only public authentication when accessing a specific repo. This can be useful when you have configured the revoker to use a particular secret by default, but need to scan a public repo which will not accept the previously configured form of auth.
+
+### SSH Keys
+
+First, generate an ssh key with a command like the below. 
+
+```bash
+ssh-keygen -t ed25519
+```
+
+Notes:
+- Not every provider will take every type of key. Refer to your provider documentation (e.x. [for github](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent#generating-a-new-ssh-key)) for exact steps on how to run this command
+- Do not use a passphrase with the key. Keys encrypted with a passphrase will not work with the application (in this case, since the passphrase would also needed to be provided to the documentation, using a passphrase would not increase the effective security of your key from the application's perspective)
+
+Second, convert your key to a format acceptable to k8s:
+
+```bash
+cat $PRIV_KEY_PATH | base64 | tr -d '\n'
+```
+
+Third, use the following yaml as a template to create the secret to store your key:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: $KEY_NAME
+  namespace: cattle-revoker-system
+type: kubernetes.io/ssh-auth
+data:
+  ssh-privatekey: $BASE_64_KEY
+```
+Using kubectl, you can create this using `kubectl create -f example.yaml`, assuming the above contents where saved to `example.yaml`.
+
+As seen above, the secret will need to be of type `kubernetes.io/ssh-auth`. Consult the [kubernetes docs](https://kubernetes.io/docs/concepts/configuration/secret/#ssh-authentication-secrets) for more information on using/creating secrets of this type. 
+
+Be sure to replace the `$KEY_NAME` with the name of the key, and `$BASE_64_KEY` with the value of the key as produced in the second step.
+
+Lastly configure a repo scan to use this key:
+
+```yaml
+apiVersion: management.cattle.io/v3
+kind: GitRepoScan
+metadata:
+  name: $SCAN_NAME
+  namespace: $SCAN_NS
+spec:
+  repoUrl: $GIT_REPO_URL 
+  scanIntervalSeconds: 600
+  repoSecretName: $KEY_NAME
+```
+Using kubectl, you can create this using `kubectl create -f example2.yaml`, assuming the above contents where saved to `example2.yaml`.
+
+Since this repo was configured to use an ssh key as the secret, be sure that the provided repoUrl (replacing `$GIT_REPO_URL`) is in ssh format (e.x. `git@github.com:MbolotSuse/rancher-token-revoker.git`).
+
+### HTTP Basic auth
+
+Note: The ssh approach is generally more secure than this approach. It's recommended that you use that approach. 
+
+This essentially requires that you provide a username/password from a user with access to the git repo. It's recommended that you attempt to scope these permissions. Some git providers will allow you to generate tokens which you can use to access these repos. It's recommended that if you  
+
+For example, github allows the creation of [Personal Access Tokens](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) which allow you to grant access only to select private repos. In the case of github, you will need to grant at least `Read only` access to `Content` to use the PAT with this tool.
+
+First, generate the password/token.
+
+Next, using the below yaml format, create the secret:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: $SECRET_NAME
+  namespace: cattle-revoker-system
+type: kubernetes.io/basic-auth
+stringData:
+  username: $USERNAME
+  password: $PASSWORD
+```
+You don't need to base64 encode username or password, the raw value should work fine.
+
+Using kubectl, you can create this using `kubectl create -f example.yaml`, assuming the above contents where saved to `example.yaml`.
+
+Lastly, configure a repo scan to use te the secret:
+
+```yaml
+apiVersion: management.cattle.io/v3
+kind: GitRepoScan
+metadata:
+  name: $SCAN_NAME
+  namespace: $SCAN_NS
+spec:
+  repoUrl: $GIT_REPO_URL 
+  scanIntervalSeconds: 600
+  repoSecretName: $KEY_NAME
+```
+
+Using kubectl, you can create this using `kubectl create -f example2.yaml`, assuming the above contents where saved to `example2.yaml`.
+
+Since this repo was configured to use a http basic auth as the secret, be sure that the provided repoUrl (replacing `$GIT_REPO_URL`) is in https format (e.x. `https://github.com/MbolotSuse/rancher-token-revoker.git`).

--- a/main.go
+++ b/main.go
@@ -43,6 +43,8 @@ var (
 	setupLog = ctrl.Log.WithName("setup")
 )
 
+const defaultNamespace = "cattle-revoker-system"
+
 func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 
@@ -73,6 +75,11 @@ func main() {
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(-1)
+	}
+
+	namespace, ok := os.LookupEnv("K8S_NAMESPACE")
+	if !ok {
+		namespace = defaultNamespace
 	}
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 
@@ -105,6 +112,7 @@ func main() {
 		Scheme:              mgr.GetScheme(),
 		DefaultScanInterval: defaultScanIntervalSeconds,
 		RevokerMode:         revokerMode,
+		Namespace:           namespace,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "GitRepoScan")
 		os.Exit(1)

--- a/main.go
+++ b/main.go
@@ -58,6 +58,7 @@ func main() {
 	var probeAddr string
 	var defaultScanIntervalSeconds int
 	var revokeMode string
+	var defaultSecret string
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
@@ -65,6 +66,7 @@ func main() {
 			"Enabling this will ensure there is only one active controller manager.")
 	flag.IntVar(&defaultScanIntervalSeconds, "default-scan-interval", 60, "Default scan interval in seconds")
 	flag.StringVar(&revokeMode, "revoke-mode", "warn", "Action to take on discovering exposed tokens. Allowed values are warn, disable, delete")
+	flag.StringVar(&defaultSecret, "default-secret", "", "Optional: default secret (in $K8S_NAMESPACE) which contains authentication value to be used by default for repo access")
 	opts := zap.Options{
 		Development: true,
 	}
@@ -113,6 +115,7 @@ func main() {
 		DefaultScanInterval: defaultScanIntervalSeconds,
 		RevokerMode:         revokerMode,
 		Namespace:           namespace,
+		DefaultAuthSecret:   defaultSecret,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "GitRepoScan")
 		os.Exit(1)


### PR DESCRIPTION
Adds support for scanning private repos.

Private repos can be scanned using http basic (username/password) auth or ssh-key based auth.

Also adds docs on configuring/using this feature.